### PR TITLE
Fix only one reading inserting on updateMeters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false
+
 language: node_js
 node_js:
   - "7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
 services:
   - postgresql
 
+addons:
+  postgresql: "9.6"
+
 env:
   - DB_USER=test DB_PASSWORD=test DB_DATABASE=travis_ci_test DB_TEST_DATABASE=travis_ci_test DB_HOST=localhost DB_PORT=5432 TOKEN_SECRET=travis SERVER_PORT=3000
 

--- a/src/server/models/Reading.js
+++ b/src/server/models/Reading.js
@@ -112,8 +112,8 @@ class Reading {
 	 * @param conn the connection to use. Defaults to the default database connection.
 	 * @returns {Promise.<>}
 	 */
-	async insertOrUpdate(conn = db) {
-		await conn.none(sqlFile('reading/insert_or_update_reading.sql'), this);
+	insertOrUpdate(conn = db) {
+		return conn.none(sqlFile('reading/insert_or_update_reading.sql'), this);
 	}
 
 	/**

--- a/src/server/test/db/readingTests.js
+++ b/src/server/test/db/readingTests.js
@@ -47,4 +47,18 @@ mocha.describe('Readings', () => {
 		const retrievedReadings = await Reading.getAllByMeterID(meter.id);
 		expect(retrievedReadings).to.have.length(2);
 	});
+	mocha.it('can be saved/updated in bulk', async () => {
+		const startTimestamp1 = moment('2017-01-01');
+		const endTimestamp1 = moment(startTimestamp1).add(1, 'hour');
+		const startTimestamp2 = moment(endTimestamp1).add(1, 'hour');
+		const endTimestamp2 = moment(startTimestamp2).add(1, 'hour');
+		const reading1 = new Reading(meter.id, 1, startTimestamp1, endTimestamp1);
+		const reading2 = new Reading(meter.id, 1, startTimestamp2, endTimestamp2);
+		// Insert reading 1 (so it will be updated)
+		await reading1.insert();
+		const reading1Updated = new Reading(meter.id, 2, startTimestamp1, endTimestamp1);
+		await Reading.insertOrUpdateAll([reading1Updated, reading2]);
+		const retrievedReadings = await Reading.getAllByMeterID(meter.id);
+		expect(retrievedReadings).to.have.length(2);
+	});
 });


### PR DESCRIPTION
Only one reading was being inserted due to a bug with the promise being returned
from a single `reading.insert()` call resolving with undefined instead of its
value from pg-promise. This prematurely ended a sequence call in `Reading.insertOrUpdateAll`