### PR TITLE
Actions and reducers for basic group editing

### DIFF
--- a/src/client/app/actions/groups.js
+++ b/src/client/app/actions/groups.js
@@ -19,6 +19,7 @@ export const GROUPSUI_CHANGE_DISPLAYED_GROUPS = 'GROUPSUI_CHANGE_DISPLAYED_GROUP
 
 export const CREATE_NEW_GROUP = 'CREATE_NEW_GROUP';
 export const EDIT_GROUP_NAME = 'EDIT_GROUP_NAME';
+export const ADOPT_CHILD_GROUPS = 'ADOPT_CHILD_GROUPS';
 
 
 function requestGroupsDetails() {
@@ -127,4 +128,13 @@ export function createNewGroup() {
 
 export function editGroupName(newName) {
 	return { type: EDIT_GROUP_NAME, newName };
+}
+
+/**
+ * Add a list of group IDs as child groups of the group in editing
+ * @param groupIDs An array of the group IDs (as integers) to be added as children
+ * @return {{type: string, groupIDs: [Int]}}
+ */
+export function adoptChildGroups(groupIDs) {
+	return { type: ADOPT_CHILD_GROUPS, groupIDs };
 }

--- a/src/client/app/actions/groups.js
+++ b/src/client/app/actions/groups.js
@@ -17,6 +17,10 @@ export const GROUPSUI_CHANGE_SELECTED_GROUPS_PER_GROUP = 'GROUPSUI_CHANGE_SELECT
 export const GROUPSUI_CHANGE_SELECTED_METERS_PER_GROUP = 'GROUPSUI_CHANGE_SELECTED_METERS_PER_GROUP';
 export const GROUPSUI_CHANGE_DISPLAYED_GROUPS = 'GROUPSUI_CHANGE_DISPLAYED_GROUPS';
 
+export const CREATE_NEW_GROUP = 'CREATE_NEW_GROUP';
+export const EDIT_GROUP_NAME = 'EDIT_GROUP_NAME';
+
+
 function requestGroupsDetails() {
 	return { type: REQUEST_GROUPS_DETAILS };
 }
@@ -117,3 +121,10 @@ export function changeSelectedMetersOfGroup(parentID, meterIDs) {
 	return { type: GROUPSUI_CHANGE_SELECTED_METERS_PER_GROUP, parentID, meterIDs };
 }
 
+export function createNewGroup() {
+	return { type: CREATE_NEW_GROUP };
+}
+
+export function editGroupName(newName) {
+	return { type: EDIT_GROUP_NAME, newName };
+}

--- a/src/client/app/actions/groups.js
+++ b/src/client/app/actions/groups.js
@@ -23,6 +23,7 @@ export const EDIT_GROUP_NAME = 'EDIT_GROUP_NAME';
 export const CHANGE_CHILD_METERS = 'CHANGE_CHILD_METERS';
 export const CHANGE_CHILD_GROUPS = 'CHANGE_CHILD_GROUPS';
 
+export const GROUPSUI_CHANGE_DISPLAY_MODE = 'GROUPSUI_CHANGE_DISPLAY_MODE';
 
 function requestGroupsDetails() {
 	return { type: REQUEST_GROUPS_DETAILS };
@@ -156,4 +157,8 @@ export function changeChildGroups(groupIDs) {
  */
 export function changeChildMeters(meterIDs) {
 	return { type: CHANGE_CHILD_METERS, meterIDs };
+}
+
+export function changeDisplayMode(newMode) {
+	return { type: GROUPSUI_CHANGE_DISPLAY_MODE, newMode };
 }

--- a/src/client/app/actions/groups.js
+++ b/src/client/app/actions/groups.js
@@ -19,10 +19,9 @@ export const GROUPSUI_CHANGE_DISPLAYED_GROUPS = 'GROUPSUI_CHANGE_DISPLAYED_GROUP
 
 export const CREATE_NEW_GROUP = 'CREATE_NEW_GROUP';
 export const EDIT_GROUP_NAME = 'EDIT_GROUP_NAME';
-export const ADOPT_CHILD_GROUPS = 'ADOPT_CHILD_GROUPS';
-export const DISOWN_CHILD_GROUPS = 'DISOWN_CHILD_GROUPS';
-export const ADOPT_CHILD_METERS = 'ADOPT_CHILD_METERS';
-export const DISOWN_CHILD_METERS = 'DISOWN_CHILD_METERS';
+
+export const CHANGE_CHILD_METERS = 'CHANGE_CHILD_METERS';
+export const CHANGE_CHILD_GROUPS = 'CHANGE_CHILD_GROUPS';
 
 
 function requestGroupsDetails() {
@@ -125,31 +124,36 @@ export function changeSelectedMetersOfGroup(parentID, meterIDs) {
 	return { type: GROUPSUI_CHANGE_SELECTED_METERS_PER_GROUP, parentID, meterIDs };
 }
 
+/**
+ * Set state.groups.groupInEditing to a blank group
+ * @return {{type: string}}
+ */
 export function createNewGroup() {
 	return { type: CREATE_NEW_GROUP };
 }
 
+/**
+ * Change the name of the group in editing
+ * @param newName The new name
+ * @return {{type: string, newName: String}}
+ */
 export function editGroupName(newName) {
 	return { type: EDIT_GROUP_NAME, newName };
 }
-
 /**
- * Add a list of group IDs as child groups of the group in editing
- * @param groupIDs An array of the group IDs (as integers) to be added as children
+ * Change the child groups of the group in editing
+ * @param groupIDs IDs of the new child groups
  * @return {{type: string, groupIDs: [Int]}}
  */
-export function adoptChildGroups(groupIDs) {
-	return { type: ADOPT_CHILD_GROUPS, groupIDs };
+export function changeChildGroups(groupIDs) {
+	return { type: CHANGE_CHILD_GROUPS, groupIDs };
 }
 
-export function disownChildGroups(groupIDs) {
-	return { type: DISOWN_CHILD_GROUPS, groupIDs };
-}
-
-export function adoptChildMeters(meterIDs) {
-	return { type: ADOPT_CHILD_METERS, meterIDs };
-}
-
-export function disownChildMeters(meterIDs) {
-	return { type: DISOWN_CHILD_METERS, meterIDs };
+/**
+ * Change the child meters of the group in editing
+ * @param meterIDs IDs of the new set of child meters
+ * @return {{type: string, meterIDs: [Int]}}
+ */
+export function changeChildMeters(meterIDs) {
+	return { type: CHANGE_CHILD_METERS, meterIDs };
 }

--- a/src/client/app/actions/groups.js
+++ b/src/client/app/actions/groups.js
@@ -21,6 +21,8 @@ export const CREATE_NEW_GROUP = 'CREATE_NEW_GROUP';
 export const EDIT_GROUP_NAME = 'EDIT_GROUP_NAME';
 export const ADOPT_CHILD_GROUPS = 'ADOPT_CHILD_GROUPS';
 export const DISOWN_CHILD_GROUPS = 'DISOWN_CHILD_GROUPS';
+export const ADOPT_CHILD_METERS = 'ADOPT_CHILD_METERS';
+export const DISOWN_CHILD_METERS = 'DISOWN_CHILD_METERS';
 
 
 function requestGroupsDetails() {
@@ -142,4 +144,12 @@ export function adoptChildGroups(groupIDs) {
 
 export function disownChildGroups(groupIDs) {
 	return { type: DISOWN_CHILD_GROUPS, groupIDs };
+}
+
+export function adoptChildMeters(meterIDs) {
+	return { type: ADOPT_CHILD_METERS, meterIDs };
+}
+
+export function disownChildMeters(meterIDs) {
+	return { type: DISOWN_CHILD_METERS, meterIDs };
 }

--- a/src/client/app/actions/groups.js
+++ b/src/client/app/actions/groups.js
@@ -20,6 +20,7 @@ export const GROUPSUI_CHANGE_DISPLAYED_GROUPS = 'GROUPSUI_CHANGE_DISPLAYED_GROUP
 export const CREATE_NEW_GROUP = 'CREATE_NEW_GROUP';
 export const EDIT_GROUP_NAME = 'EDIT_GROUP_NAME';
 export const ADOPT_CHILD_GROUPS = 'ADOPT_CHILD_GROUPS';
+export const DISOWN_CHILD_GROUPS = 'DISOWN_CHILD_GROUPS';
 
 
 function requestGroupsDetails() {
@@ -137,4 +138,8 @@ export function editGroupName(newName) {
  */
 export function adoptChildGroups(groupIDs) {
 	return { type: ADOPT_CHILD_GROUPS, groupIDs };
+}
+
+export function disownChildGroups(groupIDs) {
+	return { type: DISOWN_CHILD_GROUPS, groupIDs };
 }

--- a/src/client/app/reducers/groups.js
+++ b/src/client/app/reducers/groups.js
@@ -157,6 +157,17 @@ export default function groups(state = defaultState, action) {
 			};
 		}
 
+		case groupsActions.DISOWN_CHILD_GROUPS: {
+			const remaining = _.difference(state.groupInEditing.childGroups, action.groupIDs);
+			return {
+				...state,
+				groupInEditing: {
+					...state.groupInEditing,
+					childGroups: remaining
+				}
+			};
+		}
+
 		default:
 			return state;
 	}

--- a/src/client/app/reducers/groups.js
+++ b/src/client/app/reducers/groups.js
@@ -15,7 +15,8 @@ import * as groupsActions from '../actions/groups';
 const defaultState = {
 	isFetching: false,
 	byGroupID: {},
-	selectedGroups: []
+	selectedGroups: [],
+	groupInEditing: {},
 };
 
 /**
@@ -55,7 +56,6 @@ export default function groups(state = defaultState, action) {
 				...state,
 				isFetching: false,
 				byGroupID: newGroupsByID,
-				groupInEditing: null,
 			};
 		}
 
@@ -120,6 +120,27 @@ export default function groups(state = defaultState, action) {
 			return {
 				...state,
 				selectedGroups: action.groupIDs,
+			};
+		}
+
+		case groupsActions.CREATE_NEW_GROUP: {
+			return {
+				...state,
+				groupInEditing: {
+					name: null,
+					childGroups: [],
+					childMeters: []
+				}
+			};
+		}
+
+		case groupsActions.EDIT_GROUP_NAME: {
+			return {
+				...state,
+				groupInEditing: {
+					...state.groupInEditing,
+					name: action.newName
+				}
 			};
 		}
 

--- a/src/client/app/reducers/groups.js
+++ b/src/client/app/reducers/groups.js
@@ -145,6 +145,7 @@ export default function groups(state = defaultState, action) {
 		}
 
 		case groupsActions.ADOPT_CHILD_GROUPS: {
+			// todo: this check may not actually be necessary
 			const validGroups = Object.keys(state.byGroupID).map(id => parseInt(id));
 			const realGroups = _.intersection(validGroups, action.groupIDs);
 			const children = _.union(state.groupInEditing.childGroups, realGroups);
@@ -164,6 +165,28 @@ export default function groups(state = defaultState, action) {
 				groupInEditing: {
 					...state.groupInEditing,
 					childGroups: remaining
+				}
+			};
+		}
+
+		case groupsActions.ADOPT_CHILD_METERS: {
+			const children = _.union(state.groupInEditing.childMeters, action.meterIDs);
+			return {
+				...state,
+				groupInEditing: {
+					...state.groupInEditing,
+					childMeters: children
+				}
+			};
+		}
+
+		case groupsActions.DISOWN_CHILD_METERS: {
+			const remaining = _.difference(state.groupInEditing.childMeters, action.meterIDs);
+			return {
+				...state,
+				groupInEditing: {
+					...state.groupInEditing,
+					childMeters: remaining
 				}
 			};
 		}

--- a/src/client/app/reducers/groups.js
+++ b/src/client/app/reducers/groups.js
@@ -144,6 +144,19 @@ export default function groups(state = defaultState, action) {
 			};
 		}
 
+		case groupsActions.ADOPT_CHILD_GROUPS: {
+			const validGroups = Object.keys(state.byGroupID).map(id => parseInt(id));
+			const realGroups = _.intersection(validGroups, action.groupIDs);
+			const children = _.union(state.groupInEditing.childGroups, realGroups);
+			return {
+				...state,
+				groupInEditing: {
+					...state.groupInEditing,
+					childGroups: children
+				}
+			};
+		}
+
 		default:
 			return state;
 	}

--- a/src/client/app/reducers/groups.js
+++ b/src/client/app/reducers/groups.js
@@ -127,7 +127,7 @@ export default function groups(state = defaultState, action) {
 			return {
 				...state,
 				groupInEditing: {
-					name: null,
+					name: '',
 					childGroups: [],
 					childMeters: []
 				}
@@ -144,49 +144,22 @@ export default function groups(state = defaultState, action) {
 			};
 		}
 
-		case groupsActions.ADOPT_CHILD_GROUPS: {
-			// todo: this check may not actually be necessary
-			const validGroups = Object.keys(state.byGroupID).map(id => parseInt(id));
-			const realGroups = _.intersection(validGroups, action.groupIDs);
-			const children = _.union(state.groupInEditing.childGroups, realGroups);
+		case groupsActions.CHANGE_CHILD_GROUPS: {
 			return {
 				...state,
 				groupInEditing: {
 					...state.groupInEditing,
-					childGroups: children
+					childGroups: action.groupIDs
 				}
 			};
 		}
 
-		case groupsActions.DISOWN_CHILD_GROUPS: {
-			const remaining = _.difference(state.groupInEditing.childGroups, action.groupIDs);
+		case groupsActions.CHANGE_CHILD_METERS: {
 			return {
 				...state,
 				groupInEditing: {
 					...state.groupInEditing,
-					childGroups: remaining
-				}
-			};
-		}
-
-		case groupsActions.ADOPT_CHILD_METERS: {
-			const children = _.union(state.groupInEditing.childMeters, action.meterIDs);
-			return {
-				...state,
-				groupInEditing: {
-					...state.groupInEditing,
-					childMeters: children
-				}
-			};
-		}
-
-		case groupsActions.DISOWN_CHILD_METERS: {
-			const remaining = _.difference(state.groupInEditing.childMeters, action.meterIDs);
-			return {
-				...state,
-				groupInEditing: {
-					...state.groupInEditing,
-					childMeters: remaining
+					childMeters: action.meterIDs
 				}
 			};
 		}

--- a/src/client/app/reducers/groups.js
+++ b/src/client/app/reducers/groups.js
@@ -17,6 +17,7 @@ const defaultState = {
 	byGroupID: {},
 	selectedGroups: [],
 	groupInEditing: {},
+	displayMode: 'view'
 };
 
 /**
@@ -162,6 +163,17 @@ export default function groups(state = defaultState, action) {
 					childMeters: action.meterIDs
 				}
 			};
+		}
+
+		case groupsActions.GROUPSUI_CHANGE_DISPLAY_MODE: {
+			const validModes = ['view', 'edit', 'create'];
+			if (_.includes(validModes, action.newMode)) {
+				return {
+					...state,
+					displayMode: action.newMode
+				};
+			}
+			return state;
 		}
 
 		default:


### PR DESCRIPTION
Add actions and reducers to do the following:
* create a new group with a blank name and no children
* edit the name of the group
* add/remove child meters/groups of the group