### PR TITLE
Filter control for meters

### DIFF
--- a/src/client/app/actions/meters_filter.js
+++ b/src/client/app/actions/meters_filter.js
@@ -1,0 +1,24 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+export const METERS_FILTER_MODIFIED = 'METERS_FILTER_MODIFIED';
+export const METERS_FILTER_CLEARED = 'METERS_FILTER_CLEARED';
+
+/**
+ * Returns an action signifying that the meters filter was changed to the
+ * given term.
+ * @param {string} term The term to which the filter is set
+ */
+export function metersFilterModified(term) {
+	return { type: METERS_FILTER_MODIFIED, term: term };
+}
+
+/**
+ * Returns an action signifying that the meters filter was cleared.
+ */
+export function metersFilterCleared() {
+	return { type: METERS_FILTER_CLEARED };
+}

--- a/src/client/app/components/MetersFilterComponent.jsx
+++ b/src/client/app/components/MetersFilterComponent.jsx
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import React from 'react';
+
+// needs setFilter and clearFilter dispatchers
+// and filterTerm, the text in the box.
+export default class MetersFilterComponent extends React.Component {
+	/**
+	 * Initializes the components state, binds all functions to this.
+	 * @param props The props passed down through the MetersFilterContainer
+	 */
+	constructor(props) {
+		super(props);
+		this.handleChanged = this.handleChanged.bind(this);
+		this.handleClearButtonClicked = this.handleClearButtonClicked.bind(this);
+	}
+
+	handleChanged(event) {
+		this.props.setFilter(event.target.value);
+	}
+
+	handleClearButtonClicked() {
+		this.props.clearFilter();
+		// By default, the form field keeps its own state, so when it's
+		// cleared it needs to be invalidated so the vDOM can redraw it.
+		this.forceUpdate();
+	}
+
+	render() {
+		const filterInputStyle = {
+			maxWidth: '75%'
+		};
+		return (
+			<div className="form-inline">
+				<input type="text" className="form-control" placeholder="Filter..." style={filterInputStyle} value={this.props.filterTerm} onInput={this.handleChanged} />
+				<button className="form-control btn btn-danger" onClick={this.handleClearButtonClicked}>❌</button>
+			</div>
+		);
+	}
+}

--- a/src/client/app/components/UIOptionsComponent.jsx
+++ b/src/client/app/components/UIOptionsComponent.jsx
@@ -8,6 +8,7 @@ import moment from 'moment';
 import 'react-rangeslider/lib/index.css';
 import { chartTypes } from '../reducers/graph';
 import ExportContainer from '../containers/ExportContainer';
+import MetersFilterContainer from '../containers/MetersFilterContainer';
 
 
 export default class UIOptionsComponent extends React.Component {
@@ -85,6 +86,7 @@ export default class UIOptionsComponent extends React.Component {
 			<div className="col-xs-2" style={divPadding}>
 				<div className="col-xs-11">
 					<div>
+						<MetersFilterContainer />
 						<div className="form-group">
 							<p style={labelStyle}>Select meters:</p>
 							<select multiple className="form-control" id="meterList" size="8" onChange={this.handleMeterSelect}>

--- a/src/client/app/components/UIOptionsComponent.jsx
+++ b/src/client/app/components/UIOptionsComponent.jsx
@@ -90,9 +90,15 @@ export default class UIOptionsComponent extends React.Component {
 						<div className="form-group">
 							<p style={labelStyle}>Select meters:</p>
 							<select multiple className="form-control" id="meterList" size="8" onChange={this.handleMeterSelect}>
-								{this.props.meters.map(meter =>
-									<option key={meter.id} value={meter.id}>{meter.name}</option>
-								)}
+								{ this.props.meters.map(meter => {
+									// Only return the meters that meet the filter criterion
+									// TODO: If nicknames and descriptions are ever added, this MUST match on those too.
+									if (meter.name.toLowerCase().includes(this.props.filterTerm.toLowerCase())) {
+										return <option key={meter.id} value={meter.id}>{meter.name}</option>;
+									}
+									return null;
+								})
+								}
 							</select>
 						</div>
 					</div>

--- a/src/client/app/containers/MetersFilterContainer.jsx
+++ b/src/client/app/containers/MetersFilterContainer.jsx
@@ -1,0 +1,27 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { connect } from 'react-redux';
+import * as filtersActions from '../actions/meters_filter';
+import MetersFilterComponent from '../components/MetersFilterComponent';
+/**
+ * Takes state, maps metersFilter.metersFilterTerm to filterTerm
+ * @param {State} state The Redux state
+ */
+function mapStateToProps(state) {
+	return {
+		filterTerm: state.metersFilter.metersFilterTerm,
+	};
+}
+
+function mapDispatchToProps(dispatch) {
+	return {
+		clearFilter: () => dispatch(filtersActions.metersFilterCleared()),
+		setFilter: value => dispatch(filtersActions.metersFilterModified(value)),
+	};
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MetersFilterComponent);

--- a/src/client/app/containers/UIOptionsContainer.js
+++ b/src/client/app/containers/UIOptionsContainer.js
@@ -10,14 +10,15 @@ import { fetchMetersDetailsIfNeeded } from '../actions/meters';
 
 /**
  * @param {State} state
- * @return {{meterInfo: *, selectedMeters: Array}}
+ * @return {{meterInfo: *, selectedMeters: Array, filterTerm: string}}
  */
 function mapStateToProps(state) {
 	const sortedMeters = _.sortBy(_.values(state.meters.byMeterID).map(meter => ({ id: meter.id, name: meter.name.trim() })), 'name');
 	return {
 		meters: sortedMeters,
 		selectedMeters: state.graph.selectedMeters,
-		chartToRender: state.graph.chartToRender
+		chartToRender: state.graph.chartToRender,
+		filterTerm: state.metersFilter.metersFilterTerm,
 	};
 }
 

--- a/src/client/app/reducers/index.js
+++ b/src/client/app/reducers/index.js
@@ -6,6 +6,7 @@
 
 import { combineReducers } from 'redux';
 import meters from './meters';
+import metersFilter from './meters_filter';
 import lineReadings from './lineReadings';
 import barReadings from './barReadings';
 import graph from './graph';
@@ -23,4 +24,4 @@ import graph from './graph';
  * @param action
  * @return {State}
  */
-export default combineReducers({ meters, readings: combineReducers({ line: lineReadings, bar: barReadings }), graph });
+export default combineReducers({ meters, metersFilter, readings: combineReducers({ line: lineReadings, bar: barReadings }), graph });

--- a/src/client/app/reducers/meters_filter.js
+++ b/src/client/app/reducers/meters_filter.js
@@ -1,0 +1,37 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import * as metersFilterActions from '../actions/meters_filter';
+
+/**
+ * @typedef {Object} State~MetersFilter
+ * @property {string} metersFilterTerm
+ */
+const defaultState = {
+	metersFilterTerm: '',
+};
+
+/**
+ * @param {State~MetersFilter} state
+ * @param action
+ * @return {State~MetersFilter}
+ */
+export default function metersFilter(state = defaultState, action) {
+	switch (action.type) {
+		case metersFilterActions.METERS_FILTER_CLEARED:
+			return {
+				...state,
+				metersFilterTerm: '',
+			};
+		case metersFilterActions.METERS_FILTER_MODIFIED:
+			return {
+				...state,
+				metersFilterTerm: action.term
+			};
+		default:
+			return state;
+	}
+}


### PR DESCRIPTION
Beings to address #118 by allowing the user to filter case-insensitively on the meter's canonical name.

The primary drawback here is that if the user selects a meter and enters a filter term that excludes that meter, then selects another meter, even when holding an inclusive select key (e.g. Ctrl or Shift), the excluded meter will be lost from the selection. An overhaul to meter selection is required to address this.