### PR TITLE
Cleanup testing

### DIFF
--- a/src/server/test/db/barchartReadingsTests.js
+++ b/src/server/test/db/barchartReadingsTests.js
@@ -26,17 +26,17 @@ mocha.describe('Barchart Readings', () => {
 	const timestamp4 = timestamp3.clone().add(1, 'hour');
 	const timestamp5 = timestamp4.clone().add(1, 'hour');
 
-	mocha.beforeEach(() => db.task(async t => {
-		await new Meter(undefined, 'Meter', null, false, Meter.type.MAMAC).insert(t);
-		meter = await Meter.getByName('Meter', t);
-	}));
+	mocha.beforeEach(async () => {
+		await new Meter(undefined, 'Meter', null, false, Meter.type.MAMAC).insert();
+		meter = await Meter.getByName('Meter');
+	});
 
-	mocha.it('barchart readings with no specified time interval', () => db.task(async t => {
+	mocha.it('barchart readings with no specified time interval', async () => {
 		const reading1 = new Reading(meter.id, 100, timestamp1, timestamp2);
 		const reading2 = new Reading(meter.id, 200, timestamp2, timestamp3);
 		const reading3 = new Reading(meter.id, 300, timestamp3, timestamp4);
 		const reading4 = new Reading(meter.id, 400, timestamp4, timestamp5);
-		await Reading.insertAll([reading1, reading2, reading3, reading4], t);
+		await Reading.insertAll([reading1, reading2, reading3, reading4]);
 
 		const barchartReadings = await Reading.getBarchartReadings([meter.id], moment.duration(2, 'h'));
 		expect(barchartReadings[meter.id]).to.have.lengthOf(2);
@@ -44,14 +44,14 @@ mocha.describe('Barchart Readings', () => {
 		expect(barchartReadings[meter.id][0].reading_sum).to.equal(expectedFirstReading);
 		const expectedSecondReading = Math.floor(reading3.reading + reading4.reading);
 		expect(barchartReadings[meter.id][1].reading_sum).to.equal(expectedSecondReading);
-	}));
+	});
 
-	mocha.it('barchart readings with time interval', () => db.task(async t => {
+	mocha.it('barchart readings with time interval', async () => {
 		const reading1 = new Reading(meter.id, 10, timestamp1, timestamp2);
 		const reading2 = new Reading(meter.id, 100, timestamp2, timestamp3);
 		const reading3 = new Reading(meter.id, 1000, timestamp3, timestamp4);
 		const reading4 = new Reading(meter.id, 400, timestamp4, timestamp5);
-		await Reading.insertAll([reading1, reading2, reading3, reading4], t);
+		await Reading.insertAll([reading1, reading2, reading3, reading4]);
 
 		const startTimestamp = timestamp1.clone().add(30, 'minutes');
 		const endTimestamp = startTimestamp.clone().add(2, 'hours');
@@ -59,14 +59,14 @@ mocha.describe('Barchart Readings', () => {
 		expect(barchartReadings[meter.id]).to.have.lengthOf(1);
 		const expectedFirstReading = Math.floor((reading1.reading * 0.5) + reading2.reading + (reading3.reading * 0.5));
 		expect(barchartReadings[meter.id][0].reading_sum).to.equal(expectedFirstReading);
-	}));
+	});
 
-	mocha.it('barchart readings with overlapping duration and time interval', () => db.task(async t => {
+	mocha.it('barchart readings with overlapping duration and time interval', async () => {
 		const reading1 = new Reading(meter.id, 10, timestamp1, timestamp2);
 		const reading2 = new Reading(meter.id, 100, timestamp2, timestamp3);
 		const reading3 = new Reading(meter.id, 1000, timestamp3, timestamp4);
 		const reading4 = new Reading(meter.id, 400, timestamp4, timestamp5);
-		await Reading.insertAll([reading1, reading2, reading3, reading4], t);
+		await Reading.insertAll([reading1, reading2, reading3, reading4]);
 
 		const startTimestamp = timestamp1.clone().add(15, 'minutes');
 		const endTimestamp = startTimestamp.clone().add(50, 'days');
@@ -80,13 +80,13 @@ mocha.describe('Barchart Readings', () => {
 		expect(barchartReadings[meter.id][2].reading_sum).to.equal(expectedThirdReading);
 		const expectedFourthReading = Math.floor(reading4.reading * 0.75);
 		expect(barchartReadings[meter.id][3].reading_sum).to.equal(expectedFourthReading);
-	}));
+	});
 
-	mocha.it('barchart readings with a missing reading', () => db.task(async t => {
+	mocha.it('barchart readings with a missing reading', async () => {
 		const reading1 = new Reading(meter.id, 10, timestamp1, timestamp2);
 		const reading2 = new Reading(meter.id, 100, timestamp2, timestamp3);
 		const reading4 = new Reading(meter.id, 400, timestamp4, timestamp5);
-		await Reading.insertAll([reading1, reading2, reading4], t);
+		await Reading.insertAll([reading1, reading2, reading4]);
 
 		const startTimestamp = timestamp1.clone().add(30, 'minutes');
 		const endTimestamp = startTimestamp.clone().add(5, 'hours');
@@ -100,12 +100,12 @@ mocha.describe('Barchart Readings', () => {
 		expect(barchartReadings[meter.id][2].reading_sum).to.equal(expectedThirdReading);
 		const expectedFourthReading = Math.floor(reading4.reading * 0.5);
 		expect(barchartReadings[meter.id][3].reading_sum).to.equal(expectedFourthReading);
-	}));
+	});
 
-	mocha.it('barchart readings with a smaller time interval than duration', () => db.task(async t => {
+	mocha.it('barchart readings with a smaller time interval than duration', async () => {
 		const reading1 = new Reading(meter.id, 100, timestamp1, timestamp2);
 		const reading2 = new Reading(meter.id, 1000, timestamp2, timestamp3);
-		await Reading.insertAll([reading1, reading2], t);
+		await Reading.insertAll([reading1, reading2]);
 
 		const startTimestamp = timestamp1.clone().add(30, 'minutes');
 		const endTimestamp = startTimestamp.clone().add(15, 'minutes');
@@ -113,17 +113,17 @@ mocha.describe('Barchart Readings', () => {
 		expect(barchartReadings[meter.id]).to.have.lengthOf(1);
 		const expectedFirstReading = Math.floor(reading1.reading * 0.25);
 		expect(barchartReadings[meter.id][0].reading_sum).to.equal(expectedFirstReading);
-	}));
+	});
 
-	mocha.it('barchart readings with multiple meters', () => db.task(async t => {
-		await new Meter(undefined, 'Meter2', null, false, Meter.type.MAMAC).insert(t);
-		await new Meter(undefined, 'Meter3', null, false, Meter.type.MAMAC).insert(t);
-		const meter2 = await Meter.getByName('Meter2', t);
-		const meter3 = await Meter.getByName('Meter3', t);
+	mocha.it('barchart readings with multiple meters', async () => {
+		await new Meter(undefined, 'Meter2', null, false, Meter.type.MAMAC).insert();
+		await new Meter(undefined, 'Meter3', null, false, Meter.type.MAMAC).insert();
+		const meter2 = await Meter.getByName('Meter2');
+		const meter3 = await Meter.getByName('Meter3');
 		const readingMeter1 = new Reading(meter.id, 100, timestamp1, timestamp2);
 		const readingMeter2 = new Reading(meter2.id, 200, timestamp1, timestamp2);
 		const readingMeter3 = new Reading(meter3.id, 300, timestamp1, timestamp2);
-		await Reading.insertAll([readingMeter1, readingMeter2, readingMeter3], t);
+		await Reading.insertAll([readingMeter1, readingMeter2, readingMeter3]);
 
 		const startTimestamp = timestamp1.clone();
 		const endTimestamp = startTimestamp.clone().add(2, 'hours');
@@ -135,5 +135,5 @@ mocha.describe('Barchart Readings', () => {
 		expect(barchartReadings[meter.id][0].reading_sum).to.equal(readingMeter1.reading);
 		expect(barchartReadings[meter2.id][0].reading_sum).to.equal(readingMeter2.reading);
 		expect(barchartReadings[meter3.id][0].reading_sum).to.equal(readingMeter3.reading);
-	}));
+	});
 });

--- a/src/server/test/db/common.js
+++ b/src/server/test/db/common.js
@@ -17,13 +17,13 @@ config.database = {
 
 const { db, createSchema } = require('../../models/database');
 
-function recreateDB() {
-	return db.none('DROP TABLE IF EXISTS readings')
-		.then(() => db.none('DROP TABLE IF EXISTS meters'))
-		.then(() => db.none('DROP TYPE IF EXISTS meter_type'))
-		.then(() => db.none('DROP FUNCTION IF EXISTS compressed_readings(INTEGER[], TIMESTAMP, TIMESTAMP, INTEGER);'))
-		.then(() => db.none('DROP FUNCTION IF EXISTS barchart_readings(INTEGER[], INTERVAL, TIMESTAMP, TIMESTAMP);'))
-		.then(createSchema);
+async function recreateDB() {
+	await db.none('DROP TABLE IF EXISTS readings');
+	await db.none('DROP TABLE IF EXISTS meters');
+	await db.none('DROP TYPE IF EXISTS meter_type');
+	await db.none('DROP FUNCTION IF EXISTS compressed_readings(INTEGER[], TIMESTAMP, TIMESTAMP, INTEGER);');
+	await db.none('DROP FUNCTION IF EXISTS barchart_readings(INTEGER[], INTERVAL, TIMESTAMP, TIMESTAMP);');
+	await createSchema();
 }
 
 module.exports.recreateDB = recreateDB;

--- a/src/server/test/db/insertMamacReadingsFromCSVTests.js
+++ b/src/server/test/db/insertMamacReadingsFromCSVTests.js
@@ -27,18 +27,24 @@ mocha.describe('Insert Mamac readings from a file', () => {
 		meter = await Meter.getByName('Meter');
 	});
 
-	mocha.it('loads the correct number of rows from a file', () => {
+	mocha.it('loads the correct number of rows from a file', async () => {
 		const testFilePath = path.join(__dirname, 'test-readings.csv');
 		const readingDuration = moment.duration(1, 'hours');
-		return loadMamacReadingsFromCsvFile(testFilePath, meter, readingDuration)
-			.then(() => db.one('SELECT COUNT(*) as count FROM readings'))
-			.then(({ count }) => expect(parseInt(count)).to.equal(20));
+		await loadMamacReadingsFromCsvFile(testFilePath, meter, readingDuration);
+		const { count } = await db.one('SELECT COUNT(*) as count FROM readings');
+		expect(parseInt(count)).to.equal(20);
 	});
 
-	mocha.it('errors correctly on an invalid file', () => {
+	mocha.it('errors correctly on an invalid file', async () => {
 		const testFilePath = path.join(__dirname, 'test-readings-invalid.csv');
 		const readingDuration = moment.duration(1, 'hours');
-		return expect(loadMamacReadingsFromCsvFile(testFilePath, meter, readingDuration)).to.eventually.be.rejected;
+
+		try {
+			await loadMamacReadingsFromCsvFile(testFilePath, meter, readingDuration);
+			expect.fail('should have thrown an exception');
+		} catch (e) {
+			// We want this to error
+		}
 	});
 	mocha.it('rolls back correctly when it rejects', async () => {
 		const testFilePath = path.join(__dirname, 'test-readings-invalid.csv');

--- a/src/server/test/db/insertMamacReadingsFromCSVTests.js
+++ b/src/server/test/db/insertMamacReadingsFromCSVTests.js
@@ -22,10 +22,10 @@ const mocha = require('mocha');
 mocha.describe('Insert Mamac readings from a file', () => {
 	mocha.beforeEach(recreateDB);
 	let meter;
-	mocha.beforeEach(() => db.task(function* setupTests(t) {
-		yield new Meter(undefined, 'Meter', null, false, Meter.type.MAMAC).insert(t);
-		meter = yield Meter.getByName('Meter', t);
-	}));
+	mocha.beforeEach(async () => {
+		await new Meter(undefined, 'Meter', null, false, Meter.type.MAMAC).insert();
+		meter = await Meter.getByName('Meter');
+	});
 
 	mocha.it('loads the correct number of rows from a file', () => {
 		const testFilePath = path.join(__dirname, 'test-readings.csv');

--- a/src/server/test/db/readingTests.js
+++ b/src/server/test/db/readingTests.js
@@ -19,23 +19,23 @@ const mocha = require('mocha');
 mocha.describe('Readings', () => {
 	mocha.beforeEach(recreateDB);
 	let meter;
-	mocha.beforeEach(() => db.task(function* setupTests(t) {
-		yield new Meter(undefined, 'Meter', null, false, Meter.type.MAMAC).insert(t);
-		meter = yield Meter.getByName('Meter', t);
-	}));
+	mocha.beforeEach(async () => {
+		await new Meter(undefined, 'Meter', null, false, Meter.type.MAMAC).insert();
+		meter = await Meter.getByName('Meter');
+	});
 
-	mocha.it('can be saved and retrieved', () => db.task(function* runTest(t) {
+	mocha.it('can be saved and retrieved', async () => {
 		const startTimestamp = moment('2017-01-01');
 		const endTimestamp = moment('2017-01-01').add(1, 'hour');
 		const readingPreInsert = new Reading(meter.id, 10, startTimestamp, endTimestamp);
-		yield readingPreInsert.insert(t);
-		const retrievedReadings = yield Reading.getAllByMeterID(meter.id, t);
+		await readingPreInsert.insert();
+		const retrievedReadings = await Reading.getAllByMeterID(meter.id);
 		expect(retrievedReadings).to.have.lengthOf(1);
 		const readingPostInsert = retrievedReadings[0];
 		expect(readingPostInsert.startTimestamp.isSame(startTimestamp)).to.equal(true);
 		expect(readingPostInsert.endTimestamp.isSame(endTimestamp)).to.equal(true);
 		expect(readingPostInsert).to.have.property('reading', readingPreInsert.reading);
-	}));
+	});
 	mocha.it('can be saved in bulk', async () => {
 		const startTimestamp1 = moment('2017-01-01');
 		const endTimestamp1 = moment(startTimestamp1).add(1, 'hour');


### PR DESCRIPTION
Lots of our tests were using the `db.task()` generator pattern because they were written before async / await. This updates them all to async / await, which is simpler and less error-prone.